### PR TITLE
Lazy load settings instead of requiring them on load. Also fixed server crash when an unknown username is supplied.

### DIFF
--- a/.versions
+++ b/.versions
@@ -31,7 +31,6 @@ routepolicy@1.0.5
 service-configuration@1.0.4
 spacebars@1.0.6
 spacebars-compiler@1.0.6
-tdamsma:meteor-accounts-ldap@0.4.0
 templating@1.1.1
 tracker@1.0.7
 ui@1.0.6

--- a/ldap_server.coffee
+++ b/ldap_server.coffee
@@ -3,8 +3,6 @@ Future = Npm.require('fibers/future')
 assert = Npm.require('assert')
 
 console.log 'Doing ldap stuff'
-if !Meteor.settings.ldap
-  throw new Error('LDAP settings missing.')
 
 class UserQuery
   constructor: (username) -> 

--- a/ldap_server.coffee
+++ b/ldap_server.coffee
@@ -6,6 +6,9 @@ console.log 'Doing ldap stuff'
 
 class UserQuery
   constructor: (username) -> 
+    if !Meteor.settings.ldap
+      throw new Error('LDAP settings missing.')
+
     @ad = ActiveDirectory({
       url: Meteor.settings.ldap.url,
       baseDN: Meteor.settings.ldap.baseDn,
@@ -96,6 +99,9 @@ class UserQuery
     return isMemberFuture.wait()
 
   queryMembershipAndAddToMeteor: (callback) ->
+    if !Meteor.settings.ldap
+      throw new Error('LDAP settings missing.')
+
     for groupName in Meteor.settings.ldap.groupMembership
         ad = @ad
         userObj = @userObj

--- a/ldap_server.coffee
+++ b/ldap_server.coffee
@@ -31,6 +31,7 @@ class UserQuery
 
   findUser: () -> 
     userFuture = new Future
+    username = @username
 
     @ad.findUser @username, (err, userObj) ->
       if err

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   'summary': 'Meteor account login via LDAP using activedirectory.js',
   'version': '0.1.0',
-  'git' : 'https://github.com/tdamsma/meteor-accounts-ldap',
+  'git' : 'https://github.com/kevinbrowntech/meteor-accounts-ldap',
   'name' : 'make:meteor-accounts-ldap'
 });
 

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
   'summary': 'Meteor account login via LDAP using activedirectory.js',
   'version': '0.1.0',
   'git' : 'https://github.com/tdamsma/meteor-accounts-ldap',
-  'name' : 'tdamsma:meteor-accounts-ldap'
+  'name' : 'make:meteor-accounts-ldap'
 });
 
 Npm.depends({'activedirectory' : '0.6.3' , 'connect' : '2.19.3'});

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   'summary': 'Meteor account login via LDAP using activedirectory.js',
   'version': '0.1.1',
-  'git' : 'https://github.com/kevinbrowntech/meteor-accounts-ldap',
+  'git' : 'https://github.com/tdamsma/meteor-accounts-ldap',
   'name' : 'tdamsma:meteor-accounts-ldap'
 });
 

--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
   'summary': 'Meteor account login via LDAP using activedirectory.js',
-  'version': '0.1.0',
+  'version': '0.1.1',
   'git' : 'https://github.com/kevinbrowntech/meteor-accounts-ldap',
-  'name' : 'make:meteor-accounts-ldap'
+  'name' : 'tdamsma:meteor-accounts-ldap'
 });
 
 Npm.depends({'activedirectory' : '0.6.3' , 'connect' : '2.19.3'});


### PR DESCRIPTION
Hi there,

First off, thanks for writing this package. This is awesome!

This pull request does a couple of things. First off it makes the package check for settings only when they're needed, not on startup. I'm dynamically supplying settings to the app from code in the server/ directory, so this is really handy for me.

Also, I found that without the change to findUser() when you login with an unknown username, the whole server goes down, saying username is undefined.

I can continue to use my branch without this being merged back in, but it'd be awesome to have these changes back in the original package so we can all work together.
