### PR TITLE
change password key to make it compatible with accounts-password

### DIFF
--- a/ldap_client.js
+++ b/ldap_client.js
@@ -25,7 +25,7 @@ Template.ldapLogin.events({
 
 Meteor.loginWithLdap = function (username, password, callback) {
   Accounts.callLoginMethod({
-    methodArguments: [{username: username, password: password, ldap: true}],
+    methodArguments: [{username: username, pass: password, ldap: true}],
     validateResult: function (result) {
     },
     userCallback: callback

--- a/ldap_server.coffee
+++ b/ldap_server.coffee
@@ -130,13 +130,14 @@ Accounts.registerLoginHandler 'ldap', (request) ->
 
   user_query.findUser() # Allows both sAMAccountName and email
   # 2. authenticate user
-  authenticated = user_query.authenticate(request.password)
+  authenticated = user_query.authenticate(request.pass)
   
   console.log('* AUTENTICATED:',authenticated)
 
   # 3. update database
   userId = undefined
   userObj = user_query.userObj
+  userObj.username = request.username
   user = Meteor.users.findOne(dn: userObj.dn)
   if user
     userId = user._id

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   'summary': 'Meteor account login via LDAP using activedirectory.js',
-  'version': '0.1.2',
+  'version': '0.1.3',
   'git' : 'https://github.com/tdamsma/meteor-accounts-ldap',
   'name' : 'tdamsma:meteor-accounts-ldap'
 });


### PR DESCRIPTION
Hi,

Since I upgraded to Meteor 1.2, I had this error message:

```
> I20150925-17:48:45.897(2)? Exception while invoking method 'login' Error: Match error: Unknown key in field username
I20150925-17:48:45.898(2)?     at packages/check/packages/check.js:307:1
I20150925-17:48:45.898(2)?     at Function._.each._.forEach (packages/underscore/packages/underscore.js:142:1)
I20150925-17:48:45.898(2)?     at checkSubtree (packages/check/packages/check.js:298:1)
I20150925-17:48:45.898(2)?     at check (packages/check/packages/check.js:40:1)
I20150925-17:48:45.898(2)?     at [object Object].Accounts.registerLoginHandler.check.user (packages/accounts-password/password_server.js:248:1)
I20150925-17:48:45.898(2)?     at accounts_server.js:462:32
I20150925-17:48:45.899(2)?     at tryLoginMethod (accounts_server.js:239:14)
I20150925-17:48:45.899(2)?     at AccountsServer.Ap._runLoginHandlers (accounts_server.js:459:18)
I20150925-17:48:45.899(2)?     at [object Object].methods.login (accounts_server.js:522:27)
I20150925-17:48:45.899(2)?     at maybeAuditArgumentChecks (livedata_server.js:1692:12)
I20150925-17:48:45.899(2)? Sanitized and reported to the client as: Match failed [400]
I20150925-17:48:45.899(2)?
```

I figured out that it is because the "accounts-password" sees that there is a "password" field, so it tries to autenticate with it.
